### PR TITLE
JSON ADT representation with pretty printers and tests.

### DIFF
--- a/json/src/main/scala/Json.scala
+++ b/json/src/main/scala/Json.scala
@@ -1,1 +1,67 @@
 package com.jpmc.json
+
+sealed trait Json extends Product with Serializable
+
+object Json {
+
+  case class String(str: java.lang.String) extends Json
+
+  case class Boolean(value: java.lang.Boolean) extends Json
+
+  case class Number(num: Int) extends Json
+
+  case object Null extends Json
+
+  def apply(str: java.lang.String): Json = String(str)
+
+  def apply(bool: java.lang.Boolean): Json = Boolean(bool)
+
+  def apply(num: Int): Json = Number(num)
+
+  sealed trait Doc extends Json
+
+  case class Array(data: List[Json]) extends Doc
+
+  case class Object(data: Map[java.lang.String, Json]) extends Doc
+
+  def apply(data: Json*): Doc = Array(data.toList)
+
+  def prettyPrint(json: Json): java.lang.String = {
+    val quotes = "\""
+    json match {
+      case jsonDoc: Doc => prettyPrintDoc(jsonDoc)
+      case Json.String(str) => quotes + str + quotes
+      case Json.Boolean(bool) => bool.toString
+      case Json.Number(num) => num.toString
+      case Json.Null => "null"
+    }
+  }
+
+  private def prettyPrintDoc(jsonDoc: Doc): java.lang.String = {
+    val separator = ", "
+    val openSquare = "["
+    val closeSquare = "]"
+    val quotes = "\""
+    val colon = ": "
+    val openCurly = "{"
+    val closeCurly = "}"
+    jsonDoc match {
+      case Array(data) =>
+        data.map(prettyPrint).mkString(openSquare, separator, closeSquare)
+      case Object(data) =>
+        data.map {
+          case (key, value) => s"$quotes$key$quotes$colon${prettyPrint(value)}"
+        }.mkString(openCurly, separator, closeCurly)
+    }
+  }
+
+  def removeNullValues(jsonDoc: Doc): Doc = {
+    jsonDoc match {
+      case Array(_) => jsonDoc
+      case Object(data) => Object(data = data.collect {
+        case (key, obj: Json.Object) => key -> removeNullValues(obj)
+        case (key, json: Json) if json != Null => key -> json
+      })
+    }
+  }
+}

--- a/json/src/test/scala/JsonTests.scala
+++ b/json/src/test/scala/JsonTests.scala
@@ -1,13 +1,57 @@
 package com.jpmc.json
 
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import org.scalatest.freespec.AnyFreeSpec
+import Json._
 
-class JsonTests extends AnyFunSuite with ScalaCheckPropertyChecks with Matchers {
-  test("Some test") {
-    forAll { str: String =>
-      str should be(str)
+class JsonTests extends AnyFreeSpec {
+  "Pretty printing of Docs with Nulls" - {
+    "Object works" in {
+      val jsonObject = Object(Map(
+        "name" -> String("Monica"),
+        "age" -> Number(24),
+        "items" -> Array(List(String("glasses"), Null, Boolean(true))),
+        "addressInfo" -> Object(Map(
+          "streetName" -> String("Sun Street"),
+          "country" -> String("UK"),
+          "county" -> Null
+        ))
+      ))
+      val printed = prettyPrint(jsonObject)
+      val expected = """{"name": "Monica", "age": 24, "items": ["glasses", null, true], "addressInfo": {"streetName": "Sun Street", "country": "UK", "county": null}}"""
+      assert(printed == expected)
+    }
+    "Array works" in {
+      val jsonArray = Array(List(Number(123), Boolean(false), String("Hello arr!"), Null))
+      val printed = prettyPrint(jsonArray)
+      val expected = """[123, false, "Hello arr!", null]"""
+      assert(printed == expected)
+    }
+  }
+  "Pretty printing of Docs with Nulls removed" - {
+    val jsonNulls = Object(Map(
+      "obj1" -> Object(Map(
+        "null1" -> Null,
+        "obj2" -> Object(Map(
+          "null2" -> Null,
+          "list" -> Array(List(Null, String("entryToList")))
+        ))
+      ))
+    ))
+    val json = Object(Map(
+      "obj1" -> Object(Map(
+        "obj2" -> Object(Map(
+          "list" -> Array(List(Null, String("entryToList")))
+        ))
+      ))
+    ))
+    val removed = removeNullValues(jsonNulls)
+    "removing nulls works" in {
+      assert(removed == json)
+    }
+    "printing works" in {
+      val printed = prettyPrint(removed)
+      val expected = """{"obj1": {"obj2": {"list": [null, "entryToList"]}}}"""
+      assert(printed == expected)
     }
   }
 }


### PR DESCRIPTION
This PR provides a JSON ADT along with the following interpreters:
- `prettyPrint` this takes a Json and returns the String version.
- `prettyPrintDoc` this handles the specific pretty printing of Objects and Arrays.
- `removeNullValues` this removes null values from Objects recursively.