### PR TITLE
Encoder implementation for JSON Encoding and respective tests

### DIFF
--- a/codecs/src/main/scala/Encoder.scala
+++ b/codecs/src/main/scala/Encoder.scala
@@ -1,1 +1,84 @@
 package com.jpmc.codecs
+
+import com.jpmc.json._
+
+import java.time.LocalDate
+
+trait Encoder[A] {
+  def encode(value: A): Json
+}
+
+object Encoder {
+  def apply[A](implicit encoder: Encoder[A]): Encoder[A] = encoder
+
+  def from[A](f: A => Json): Encoder[A] = (a: A) => f(a)
+
+  implicit class EncoderOps[A](a: A) {
+    def asJson(implicit encoder: Encoder[A]): Json = encoder.encode(a)
+  }
+  def encode[A](value: A)(implicit encoder: Encoder[A]): Json = {
+    encoder.encode(value)
+  }
+
+  implicit val stringEncoder: Encoder[java.lang.String] = from(Json.String)
+  implicit val intEncoder: Encoder[scala.Int] = from(Json.Number)
+  implicit val boolEncoder: Encoder[scala.Boolean] = from(bool => Json.Boolean(bool))
+  implicit val dateEncoder: Encoder[LocalDate] = from(date => Json.String(date.toString))
+
+  implicit def optionEncoder[A: Encoder]: Encoder[Option[A]] = {
+    case Some(value) => value.asJson
+    case None => Json.Null
+  }
+
+  implicit def listEncoder[A: Encoder]: Encoder[List[A]] = from { data =>
+    Json.Array(data.map(_.asJson))
+  }
+
+  implicit def vectorEncoder[A: Encoder]: Encoder[Vector[A]] = from { data =>
+    Json.Array(data.map(_.asJson).toList)
+  }
+
+  implicit def tuple2Encoder[A: Encoder, B: Encoder]: Encoder[Tuple2[A, B]] = from {
+    tup =>
+      Json.Object(
+        Map("1" -> tup._1.asJson,
+            "2" -> tup._2.asJson
+        ))
+  }
+
+  implicit def tuple3Encoder[A: Encoder, B: Encoder, C: Encoder]: Encoder[Tuple3[A, B, C]] = from {
+    tup =>
+      Json.Object(
+        Map("1" -> tup._1.asJson,
+            "2" -> tup._2.asJson,
+            "3" -> tup._3.asJson
+        ))
+  }
+
+  implicit def eitherEncoder[A: Encoder, B: Encoder]: Encoder[Either[A, B]] = {
+    case Right(value) => Json.Object(Map("right" -> value.asJson))
+    case Left(value)  => Json.Object(Map("left" -> value.asJson))
+  }
+
+  implicit val kindEncoder: Encoder[User.Kind] = {
+    case User.Kind.Privileged => Json.String("Privileged")
+    case User.Kind.Normal => Json.String("Normal")
+    case User.Kind.Guest => Json.String("Guest")
+  }
+
+  implicit val userEncoder: Encoder[User] = from { user => {
+    Json.Object(Map("name" -> user.name.asJson, "age" -> user.age.asJson, "kind" -> user.kind.asJson))
+  }}
+
+  case class User(name: java.lang.String, age: Int, kind: User.Kind)
+
+  object User {
+    sealed trait Kind
+    object Kind {
+      case object Privileged extends Kind
+      case object Normal extends Kind
+      case object Guest extends Kind
+    }
+  }
+}
+

--- a/codecs/src/test/scala/EncoderTests.scala
+++ b/codecs/src/test/scala/EncoderTests.scala
@@ -1,13 +1,114 @@
 package com.jpmc.codecs
 
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import com.jpmc.codecs.Encoder.User
+import com.jpmc.json.Json
+import org.scalatest.freespec.AnyFreeSpec
 
-class EncoderTests extends AnyFunSuite with ScalaCheckPropertyChecks with Matchers {
-  test("Some test") {
-    forAll { str: String =>
-      str should be(str)
+import java.time.LocalDate
+
+class EncoderTests extends AnyFreeSpec {
+
+  "Boolean Encoder" in {
+    val booleanTrue = true
+    val result = Encoder.encode(booleanTrue)
+    val expected = Json.Boolean(true)
+    assert(result == expected)
+  }
+
+  "String Encoder" in {
+    val stringExample = "John Doe"
+    val result = Encoder.encode(stringExample)
+    val expected = Json.String("John Doe")
+    assert(result == expected)
+  }
+
+  "Integer Encoder" in {
+    val numberExample = 10
+    val result = Encoder.encode(numberExample)
+    val expected = Json.Number(10)
+    assert(result == expected)
+  }
+
+  "Date Encoder" in {
+    val dateExample = LocalDate.of(2012, 10, 1)
+    val result = Encoder.encode(dateExample)
+    val expected = Json.String("2012-10-01")
+    assert(result == expected)
+  }
+
+    "Tuple2 Encoder" in {
+      val example: Tuple2[String, Int] = ("John Doe", 100)
+      val result = Encoder.encode(example)
+      val expected =
+        Json.Object(
+          Map(
+            "1" -> Json.String("John Doe"),
+            "2" -> Json.Number(100)
+          )
+        )
+      assert(result == expected)
     }
+
+    "Tuple3 Encoder" in {
+      val example: Tuple3[String, Int, Boolean] = ("John Doe", 100, false)
+      val result = Encoder.encode(example)
+      val expected =
+        Json.Object(
+          Map(
+            "1" -> Json.String("John Doe"),
+            "2" -> Json.Number(100),
+            "3" -> Json.Boolean(false)
+          )
+        )
+      assert(result == expected)
+    }
+
+  "List Encoder" in {
+    val example = List("A", "B", "C", "D")
+    val result = Encoder.encode(example)
+    val expected = Json.Array(List(Json.String("A"), Json.String("B"), Json.String("C"),Json.String("D")))
+    assert(result == expected)
+  }
+
+  "Vector Encoder" in {
+    val example = Vector("A", "B", "C", "D")
+    val result = Encoder.encode(example)
+    val expected = Json.Array(List(Json.String("A"), Json.String("B"), Json.String("C"), Json.String("D")))
+    assert(result == expected)
+  }
+
+  "Option Encoder - Some" in {
+    val example: Option[Int] = Some(10)
+    val result = Encoder.encode(example)
+    val expected = Json.Number(10)
+    assert(result == expected)
+  }
+
+  "Option Encoder - None" in {
+    val example: Option[Int] = None
+    val result = Encoder.encode(example)
+    val expected = Json.Null
+    assert(result == expected)
+  }
+
+  "Either Encoder Left case - Int, Int" in {
+    val example: Either[Int, Int] = Left(4)
+    val result = Encoder.encode(example)
+    val expected = Json.Object(Map("left" -> Json.Number(4)))
+    assert(result == expected)
+  }
+
+  "Either Encoder Right case - Int, Int" in {
+    val example: Either[Int, Int] = Right(4)
+    val result = Encoder.encode(example)
+    val expected = Json.Object(Map("right" -> Json.Number(4)))
+    assert(result == expected)
+  }
+
+  "User encoded correctly" in {
+    val example = User("Monica", 24, User.Kind.Guest)
+    val result = Encoder.encode(example)
+    val expected = Json.Object(Map("name" -> Json.String("Monica"), "age" -> Json.Number(24), "kind" -> Json.String("Guest")))
+    assert(result == expected)
   }
 }


### PR DESCRIPTION
The purpose of this PR is to provide an encoding implementation from type `A` to `JSON`.

Changes include the encoders for the types laid out in the `codecs/README.md file`, and tests to verify the encoding is working as expected.