### PR TITLE
Json parser implementation. 

### DIFF
--- a/json/src/main/scala/Json.scala
+++ b/json/src/main/scala/Json.scala
@@ -1,5 +1,7 @@
 package com.jpmc.json
 
+import com.jpmc.json.JsonSeparators._
+
 sealed trait Json extends Product with Serializable
 
 object Json {
@@ -27,7 +29,6 @@ object Json {
   def apply(data: Json*): Doc = Array(data.toList)
 
   def prettyPrint(json: Json): java.lang.String = {
-    val quotes = "\""
     json match {
       case jsonDoc: Doc => prettyPrintDoc(jsonDoc)
       case Json.String(str) => quotes + str + quotes
@@ -38,20 +39,13 @@ object Json {
   }
 
   private def prettyPrintDoc(jsonDoc: Doc): java.lang.String = {
-    val separator = ", "
-    val openSquare = "["
-    val closeSquare = "]"
-    val quotes = "\""
-    val colon = ": "
-    val openCurly = "{"
-    val closeCurly = "}"
     jsonDoc match {
       case Array(data) =>
-        data.map(prettyPrint).mkString(openSquare, separator, closeSquare)
+        data.map(prettyPrint).mkString(openSquare, commaSep, closeSquare)
       case Object(data) =>
         data.map {
           case (key, value) => s"$quotes$key$quotes$colon${prettyPrint(value)}"
-        }.mkString(openCurly, separator, closeCurly)
+        }.mkString(openCurly, commaSep, closeCurly)
     }
   }
 
@@ -64,4 +58,13 @@ object Json {
       })
     }
   }
+}
+object JsonSeparators {
+  val commaSep = ", "
+  val openSquare = "["
+  val closeSquare = "]"
+  val quotes = "\""
+  val colon = ": "
+  val openCurly = "{"
+  val closeCurly = "}"
 }

--- a/json/src/main/scala/JsonParser.scala
+++ b/json/src/main/scala/JsonParser.scala
@@ -1,12 +1,25 @@
+import com.jpmc.json.{Json, JsonSeparators}
 import com.jpmc.parsecs.Parser
 import com.jpmc.parsecs.Parser._
 import com.jpmc.json.Json._
+import CharParsers._
 object JsonParser {
-  def jStringStr: Parser[String] = quote *> jString <* quote
+  def jStringStr: Parser[String] = quote *> Parser.alphaNumeric.rep0.map(_.mkString).map(String) <* quote
   def jNumber: Parser[Number] = number.map(Number)
   def jBoolean: Parser[Boolean] = boolean.map(b => Boolean(b))
-  def jString: Parser[String] = Parser.alphaNumeric.rep0.map(_.mkString).map(String)
-  def quote: Parser[Char] = Parser.char('\"')
-  // think about how you would implement a parser for {...}
-  // opening char something in between then closing char
+  def jNull: Parser[Json.Null.type] = string("null").map(_ => Null)
+  def jAny: Parser[Json] = jNumber | jBoolean | jStringStr | jNull | jArray | jObject
+  def key: Parser[java.lang.String] = quote *> Parser.alphaNumeric.rep0.map(_.mkString) <* quote
+  def keyValue: Parser[List[(java.lang.String, Json)]] = ((key <* colonSep) ~ jAny).repSep0(JsonSeparators.commaSep)
+  def jArray: Parser[Array] = (openSquare *> jAny.repSep0(JsonSeparators.commaSep) <* closeSquare).map(Array)
+  def jObject: Parser[Object] = openBrace *> keyValue.map(pairs => Json.Object(pairs.toMap)) <* closeBrace
+}
+
+object CharParsers {
+  def quote: Parser[java.lang.String] = Parser.string(JsonSeparators.quotes)
+  def colonSep: Parser[java.lang.String] = Parser.string(JsonSeparators.colon)
+  def openBrace: Parser[java.lang.String] = Parser.string(JsonSeparators.openCurly)
+  def closeBrace: Parser[java.lang.String] = Parser.string(JsonSeparators.closeCurly)
+  def openSquare: Parser[java.lang.String] = Parser.string(JsonSeparators.openSquare)
+  def closeSquare: Parser[java.lang.String] = Parser.string(JsonSeparators.closeSquare)
 }

--- a/json/src/test/scala/JsonParserTest.scala
+++ b/json/src/test/scala/JsonParserTest.scala
@@ -1,14 +1,57 @@
 import com.jpmc.json.Json
+import com.jpmc.json.Json._
 import com.jpmc.parsecs.Result.Success
 import org.scalatest.freespec.AnyFreeSpec
 
 class JsonParserTest extends AnyFreeSpec {
-  "Json Parsing" ignore {
+  "Json Parsing" - {
     "Json quoted string" in {
       val str = "\"hello world\""
       val parsed = JsonParser.jStringStr.parse(str)
       val expected = Success(Json.String("hello world"), "")
       assert(parsed == expected)
     }
+
+    "Json array" in {
+      val str = "[\"hi\", 123, true]"
+      val parsed = JsonParser.jArray.parse(str)
+      val expected = Success(Json.Array(List(Json.String("hi"), Json.Number(123), Json.Boolean(true))), "")
+      assert(parsed == expected)
+    }
+
+    "key value obj" in {
+      val str = "{\"key\": \"value\", \"key2\": \"value2\"}"
+      val res = JsonParser.jObject.parse(str)
+      val expected = Success(Json.Object(Map("key" -> Json.String("value"), "key2" -> Json.String("value2"))), "")
+      assert(res == expected)
+    }
+
+    "key value obj with nested object" in {
+      val str = "{\"key\": [\"value1\", 123, true, null], \"key2\": {\"name\": \"Json\"}}"
+      val res = JsonParser.jObject.parse(str)
+      val expected = Success(Json.Object(Map("key" -> Json.Array(List(Json.String("value1"), Json.Number(123), Json.Boolean(true), Json.Null)), "key2" -> Json.Object(Map("name" -> Json.String("Json"))))), "")
+      assert(res == expected)
+    }
   }
+  "Parsing from pretty printed Json obj" - {
+    "Object works" in {
+      val jsonObject = Object(Map(
+        "name" -> String("Json"),
+        "age" -> Number(123),
+        "items" -> Array(List(String("object"), Null, Boolean(true))),
+        "addressInfo" -> Object(Map(
+          "streetName" -> String("Sun Street"),
+          "country" -> String("UK"),
+          "county" -> Null
+        ))
+      ))
+      val printed = prettyPrint(jsonObject)
+      val expected = """{"name": "Json", "age": 123, "items": ["object", null, true], "addressInfo": {"streetName": "Sun Street", "country": "UK", "county": null}}"""
+      val parsed = JsonParser.jObject.parse(expected)
+      val expectedParsed = Success(jsonObject, "")
+      assert(printed == expected)
+      assert(parsed == expectedParsed)
+    }
+  }
+
 }

--- a/parsecs/src/main/scala/Parser.scala
+++ b/parsecs/src/main/scala/Parser.scala
@@ -48,7 +48,7 @@ object Parser {
   def alphaNumericChar: Parser[Char] = pred(c => c.isLetterOrDigit)
 }
 
-sealed trait Parser[A] {
+sealed trait Parser[+A] {
   def parse(input: String): Result[A]
 
   def map[B](f: A => B): Parser[B] = Parser.from {
@@ -100,9 +100,9 @@ sealed trait Parser[A] {
   def repSep0(sep: String): Parser[List[A]] = repSep(sep) | pure(List.empty)
 }
 
-sealed trait Result[A] extends Product with Serializable {
+sealed trait Result[+A] extends Product with Serializable {
   def map[B](f: A => B): Result[B] = this match {
-    case Result.Success(value, rest) => Result.Success(f(value), rest)
+    case Result.Success(value: A, rest) => Result.Success(f(value), rest)
     case Result.Failure(errMessage) => Result.Failure(errMessage)
   }
 }


### PR DESCRIPTION
This PR implements a parser for the `Json` ADT.

The main changes are: 

`JsonSeparators` in `Json` - I have collected all the common characters used in the `JsonParser` and the `prettyPrinter`. This just reduces duplication of the same separator characters like commas, braces, etc. 

Parser for JSON ADT - Including the more complex structures like `Object` and `Array`. 

Tests - I have added tests for:

- nested objects
- round trip from pretty printed string <-> `Json`